### PR TITLE
Feature/#5 네트워크/asURLRequest 함수 수정

### DIFF
--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BannerEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BannerEndPoint.swift
@@ -28,8 +28,7 @@ extension BannerEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BannerEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BannerEndPoint.swift
@@ -38,18 +38,7 @@ extension BannerEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestClearClimberEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestClearClimberEndPoint.swift
@@ -28,8 +28,7 @@ extension BestClearClimberEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestClearClimberEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestClearClimberEndPoint.swift
@@ -38,18 +38,7 @@ extension BestClearClimberEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestFollowGymEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestFollowGymEndPoint.swift
@@ -28,8 +28,7 @@ extension BestFollowGymEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestFollowGymEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestFollowGymEndPoint.swift
@@ -38,18 +38,8 @@ extension BestFollowGymEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
+
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestLevelClimberEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestLevelClimberEndPoint.swift
@@ -38,18 +38,7 @@ extension BestLevelClimberEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestLevelClimberEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestLevelClimberEndPoint.swift
@@ -28,8 +28,7 @@ extension BestLevelClimberEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestRecordGymEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestRecordGymEndPoint.swift
@@ -38,18 +38,7 @@ extension BestRecordGymEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestRecordGymEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestRecordGymEndPoint.swift
@@ -28,8 +28,7 @@ extension BestRecordGymEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestRouteEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestRouteEndPoint.swift
@@ -38,18 +38,7 @@ extension BestRouteEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestRouteEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestRouteEndPoint.swift
@@ -28,8 +28,7 @@ extension BestRouteEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestTimeClimberEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestTimeClimberEndPoint.swift
@@ -38,18 +38,7 @@ extension BestTimeClimberEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestTimeClimberEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BestTimeClimberEndPoint.swift
@@ -28,8 +28,7 @@ extension BestTimeClimberEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BlockUserEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BlockUserEndPoint.swift
@@ -27,9 +27,10 @@ extension BlockUserEndPoint: Endpoint {
         }
     }
     
-    var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+    var headers: HTTPHeaders? {
+        switch self {
+        case .usersBlock: nil
+        }
     }
     
     var body: Alamofire.Parameters? {
@@ -38,18 +39,7 @@ extension BlockUserEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BoardEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BoardEndPoint.swift
@@ -43,18 +43,7 @@ extension BoardEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BoardEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BoardEndPoint.swift
@@ -32,8 +32,7 @@ extension BoardEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BoardLikeEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BoardLikeEndPoint.swift
@@ -32,8 +32,7 @@ extension BoardLikeEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/BoardLikeEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/BoardLikeEndPoint.swift
@@ -43,18 +43,7 @@ extension BoardLikeEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimberEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimberEndPoint.swift
@@ -70,8 +70,7 @@ extension ClimberEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimberEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimberEndPoint.swift
@@ -102,18 +102,7 @@ extension ClimberEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingGymEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingGymEndPoint.swift
@@ -64,8 +64,7 @@ extension ClimbingGymEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingGymEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingGymEndPoint.swift
@@ -87,18 +87,7 @@ extension ClimbingGymEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingRecordsEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingRecordsEndPoint.swift
@@ -81,8 +81,7 @@ extension ClimbingRecordsEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingRecordsEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingRecordsEndPoint.swift
@@ -104,18 +104,7 @@ extension ClimbingRecordsEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingReviewEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingReviewEndPoint.swift
@@ -41,8 +41,7 @@ extension ClimbingReviewEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingReviewEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingReviewEndPoint.swift
@@ -57,18 +57,7 @@ extension ClimbingReviewEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingRouteEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingRouteEndPoint.swift
@@ -30,8 +30,7 @@ extension ClimbingRouteEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingRouteEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingRouteEndPoint.swift
@@ -40,18 +40,7 @@ extension ClimbingRouteEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingSectorEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingSectorEndPoint.swift
@@ -38,18 +38,7 @@ extension ClimbingSectorEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingSectorEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ClimbingSectorEndPoint.swift
@@ -28,8 +28,7 @@ extension ClimbingSectorEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/DifficultyMappingEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/DifficultyMappingEndPoint.swift
@@ -30,8 +30,7 @@ extension DifficultyMappingEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/DifficultyMappingEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/DifficultyMappingEndPoint.swift
@@ -40,18 +40,7 @@ extension DifficultyMappingEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/EvaluationEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/EvaluationEndPoint.swift
@@ -28,8 +28,7 @@ extension EvaluationEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/EvaluationEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/EvaluationEndPoint.swift
@@ -42,18 +42,7 @@ extension EvaluationEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/FollowEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/FollowEndPoint.swift
@@ -48,16 +48,5 @@ extension FollowEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
+    var token: String? { KeyChain.shared.refreshToken }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/FollowEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/FollowEndPoint.swift
@@ -38,8 +38,7 @@ extension FollowEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/RouteRecordsEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/RouteRecordsEndPoint.swift
@@ -53,18 +53,7 @@ extension RouteRecordsEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/RouteRecordsEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/RouteRecordsEndPoint.swift
@@ -37,8 +37,7 @@ extension RouteRecordsEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/RouteVersionEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/RouteVersionEndPoint.swift
@@ -76,18 +76,7 @@ extension RouteVersionEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/RouteVersionEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/RouteVersionEndPoint.swift
@@ -40,8 +40,7 @@ extension RouteVersionEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/S3EndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/S3EndPoint.swift
@@ -32,8 +32,10 @@ extension S3EndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token), .contentType("multipart/form-data")]
+        switch self {
+        case .retoolUpload, .upload:
+            return .applicationJSON
+        }
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/S3EndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/S3EndPoint.swift
@@ -45,16 +45,5 @@ extension S3EndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
+    var token: String? { KeyChain.shared.refreshToken }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsBookmarkEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsBookmarkEndPoint.swift
@@ -28,8 +28,7 @@ extension ShortsBookmarkEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsBookmarkEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsBookmarkEndPoint.swift
@@ -38,16 +38,5 @@ extension ShortsBookmarkEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
+    var token: String? { KeyChain.shared.refreshToken }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsCommentEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsCommentEndPoint.swift
@@ -77,16 +77,5 @@ extension ShortsCommentEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
+    var token: String? { KeyChain.shared.refreshToken }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsCommentEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsCommentEndPoint.swift
@@ -66,8 +66,7 @@ extension ShortsCommentEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsEndPoint.swift
@@ -97,12 +97,11 @@ extension ShortsEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
         switch self {
         case .upload:
-            return [.authorization(bearerToken: token), .contentType("multipart/form-data")]
+            return .applicationJSON
         default:
-            return [.authorization(bearerToken: token)]
+            return nil
         }
     }
     

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsEndPoint.swift
@@ -119,16 +119,5 @@ extension ShortsEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
+    var token: String? { KeyChain.shared.refreshToken }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsLikeEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsLikeEndPoint.swift
@@ -28,8 +28,7 @@ extension ShortsLikeEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsLikeEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/ShortsLikeEndPoint.swift
@@ -38,16 +38,5 @@ extension ShortsLikeEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
+    var token: String? { KeyChain.shared.refreshToken }
 }

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/UserEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/UserEndPoint.swift
@@ -81,8 +81,7 @@ extension UserEndPoint: Endpoint {
     }
     
     var headers: Alamofire.HTTPHeaders? {
-        guard let token else { return nil }
-        return [.authorization(bearerToken: token)]
+        return nil
     }
     
     var body: Alamofire.Parameters? {

--- a/Climeet-iOS/Climeet-iOS/Data/EndPoint/UserEndPoint.swift
+++ b/Climeet-iOS/Climeet-iOS/Data/EndPoint/UserEndPoint.swift
@@ -103,18 +103,7 @@ extension UserEndPoint: Endpoint {
         }
     }
     
-    var token: String? { UserDefaults.standard.value(forKey: "token") as? String }
+    var token: String? { KeyChain.shared.refreshToken }
     
     var multipart: Alamofire.MultipartFormData? { nil }
-    
-    func asURLRequest() throws -> URLRequest {
-        guard let url = URL(string: baseURL + path) else {
-            throw AppError.urlConvertingError("URL Component 조합 실패")
-        }
-        var request = URLRequest(url: url)
-        request.headers = headers ?? .default
-        request.method = method
-        
-        return request
-    }
 }

--- a/NetworkKit/Sources/NetworkKit/Kit/EndPoint.swift
+++ b/NetworkKit/Sources/NetworkKit/Kit/EndPoint.swift
@@ -10,3 +10,50 @@ public protocol Endpoint: URLRequestConvertible {
     var body: Parameters? { get }
     var token: String? { get }
 }
+
+extension Endpoint {
+    
+    private var defaultHeaders: HTTPHeaders {
+        var headers: HTTPHeaders = []
+        
+        if let token = token {
+            headers.add(.authorization(bearerToken: token))
+        }
+        
+        return headers
+    }
+    
+    public func asURLRequest() throws -> URLRequest {
+        guard let url = URL(string: baseURL)?.appendingPathComponent(path) else {
+            throw APIError(errorCode: "EndPoint.asURLRequest", message: "Invalid baseURL or path")
+        }
+        
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        
+        if let queryItems = queryItems {
+            components?.queryItems = queryItems.map { URLQueryItem(name: $0.name, value: $0.value) }
+        }
+        
+        guard let finalURL = components?.url else {
+            throw APIError(errorCode: "EndPoint.asURLRequest", message: "URL Component 조합 실패")
+        }
+        
+        var request = URLRequest(url: finalURL)
+        request.method = method
+        
+        // 헤더값 설정
+        var finalHeader = defaultHeaders
+        if let customHeaders = headers {
+            customHeaders.forEach { finalHeader.update($0) }
+        }
+        
+        request.headers = finalHeader
+        
+        // 파라미터 설정
+        if let parameters = body {
+            request.httpBody = try? JSONSerialization.data(withJSONObject: parameters)
+        }
+        
+        return request
+    }
+}

--- a/NetworkKit/Sources/NetworkKit/Kit/HttpHeaders +.swift
+++ b/NetworkKit/Sources/NetworkKit/Kit/HttpHeaders +.swift
@@ -4,6 +4,7 @@
 //
 //  Created by KOVI on 11/1/24.
 //
+import Alamofire
 
 extension HTTPHeaders {
     /// `Content-Type: application/json` 헤더를 포함하는 HTTPHeaders 인스턴스 반환

--- a/NetworkKit/Sources/NetworkKit/Kit/HttpHeaders +.swift
+++ b/NetworkKit/Sources/NetworkKit/Kit/HttpHeaders +.swift
@@ -1,0 +1,13 @@
+//
+//  HttpHeaders.swift
+//  NetworkKit
+//
+//  Created by KOVI on 11/1/24.
+//
+
+extension HTTPHeaders {
+    /// `Content-Type: application/json` 헤더를 포함하는 HTTPHeaders 인스턴스 반환
+    public static var applicationJSON: HTTPHeaders? {
+        return [.contentType("application/json")]
+    }
+}


### PR DESCRIPTION
close #8 

## 📓 Overview
- EndPoint의 asURLRequest를 protocol extension으로 공통구현하였습니다.

## 🤔 고민 내용

- 헤더 설정 시 토큰값은 명시하지 않으셔도 괜찮습니다.
- HTTPHeaders의 extension으로 contentType, application/json만을 만들어뒀는데 SwaggerAPI 요구사항을 보니 다른 컨텐츠타입은 필요하지않은듯합니다.
